### PR TITLE
Add settings page

### DIFF
--- a/src/pages/Settings/Settings.styles.tsx
+++ b/src/pages/Settings/Settings.styles.tsx
@@ -1,0 +1,187 @@
+import styled from 'styled-components';
+import { theme } from '../../theme';
+
+export const SettingsContainer = styled.div`
+  max-width: 100%;
+`;
+
+export const SettingsHeader = styled.div`
+  margin-bottom: ${theme.spacing.xl};
+  position: sticky;
+  top: 0;
+  background-color: ${theme.colors.background};
+  padding-top: ${theme.spacing.md};
+  padding-bottom: ${theme.spacing.md};
+  border-bottom: 1px solid ${theme.colors.border};
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  z-index: 100;
+
+  h1 {
+    color: ${theme.colors.primary};
+    margin-bottom: ${theme.spacing.sm};
+    font-size: ${theme.fontSize['4xl']};
+    font-weight: ${theme.fontWeight.bold};
+  }
+
+  p {
+    color: ${theme.colors.text.secondary};
+    font-size: ${theme.fontSize.lg};
+    line-height: 1.5;
+  }
+`;
+
+export const SettingsSections = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing.xl};
+`;
+
+export const SettingsSection = styled.section`
+  background: ${theme.colors.surface};
+  border: 1px solid ${theme.colors.border};
+  border-radius: ${theme.borderRadius.md};
+  padding: ${theme.spacing.lg};
+
+  h3 {
+    margin: 0 0 ${theme.spacing.lg} 0;
+    color: ${theme.colors.primary};
+    font-size: ${theme.fontSize.xl};
+    font-weight: ${theme.fontWeight.semibold};
+    padding-bottom: ${theme.spacing.sm};
+    border-bottom: 1px solid ${theme.colors.border};
+  }
+`;
+
+export const SettingItem = styled.div`
+  margin-bottom: ${theme.spacing.lg};
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+export const SettingLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  cursor: pointer;
+  font-weight: ${theme.fontWeight.medium};
+  color: ${theme.colors.text.primary};
+`;
+
+export const SettingDescription = styled.p`
+  color: ${theme.colors.text.secondary};
+  font-size: ${theme.fontSize.sm};
+  margin-top: ${theme.spacing.xs};
+  margin-left: ${theme.spacing.xl};
+`;
+
+export const Checkbox = styled.input.attrs({ type: 'checkbox' })`
+  width: 18px;
+  height: 18px;
+  accent-color: ${theme.colors.primary};
+  cursor: pointer;
+`;
+
+export const Select = styled.select`
+  margin-left: ${theme.spacing.sm};
+  padding: ${theme.spacing.sm};
+  border: 1px solid ${theme.colors.border};
+  border-radius: ${theme.borderRadius.sm};
+  background-color: ${theme.colors.background};
+  color: ${theme.colors.text.primary};
+  font-size: ${theme.fontSize.base};
+  min-width: 120px;
+  cursor: pointer;
+
+  &:focus {
+    outline: 2px solid ${theme.colors.primary};
+    outline-offset: 2px;
+  }
+`;
+
+export const DataActionsContainer = styled.div`
+  display: flex;
+  gap: ${theme.spacing.md};
+  flex-wrap: wrap;
+
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    flex-direction: column;
+  }
+`;
+
+export const ActionButton = styled.button<{ variant?: 'primary' | 'secondary' | 'danger' }>`
+  padding: ${theme.spacing.sm} ${theme.spacing.lg};
+  border-radius: ${theme.borderRadius.sm};
+  font-size: ${theme.fontSize.base};
+  font-weight: ${theme.fontWeight.medium};
+  transition: all ${theme.transitions.fast};
+  min-width: 160px;
+
+  ${props => props.variant === 'primary' && `
+    background-color: ${theme.colors.primary};
+    color: ${theme.colors.text.white};
+
+    &:hover {
+      background-color: ${theme.colors.primaryHover};
+    }
+  `}
+
+  ${props => props.variant === 'secondary' && `
+    background-color: ${theme.colors.secondary};
+    color: ${theme.colors.text.white};
+
+    &:hover {
+      background-color: ${theme.colors.secondaryHover};
+    }
+  `}
+
+  ${props => props.variant === 'danger' && `
+    background-color: #dc3545;
+    color: ${theme.colors.text.white};
+
+    &:hover {
+      background-color: #c82333;
+    }
+  `}
+
+  ${props => !props.variant && `
+    background-color: ${theme.colors.surface};
+    color: ${theme.colors.text.primary};
+    border: 1px solid ${theme.colors.border};
+
+    &:hover {
+      background-color: ${theme.colors.border};
+    }
+  `}
+
+  &:focus {
+    outline: 2px solid ${theme.colors.primary};
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+export const SettingRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: ${theme.spacing.md};
+
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
+export const SettingContent = styled.div`
+  flex: 1;
+`;
+
+export const SettingControl = styled.div`
+  flex-shrink: 0;
+`;

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -1,8 +1,268 @@
-import React from 'react';
+import React, { useState } from 'react';
+import {
+    SettingsContainer,
+    SettingsHeader,
+    SettingsSections,
+    SettingsSection,
+    SettingItem,
+    SettingLabel,
+    SettingDescription,
+    Checkbox,
+    Select,
+    DataActionsContainer,
+    ActionButton,
+    SettingRow,
+    SettingContent,
+    SettingControl,
+} from './Settings.styles';
+import type { ToggleSettingProps, SelectSettingProps, SettingsProps, UserSettings } from './Settings.types';
 
+const ToggleSetting: React.FC<ToggleSettingProps> = ({
+    label,
+    description,
+    checked,
+    onChange,
+}) => (
+    <SettingItem>
+        <SettingRow>
+            <SettingContent>
+                <SettingLabel>
+                    <Checkbox
+                        checked={checked}
+                        onChange={(e) => onChange(e.target.checked)}
+                    />
+                    {label}
+                </SettingLabel>
+                {description && <SettingDescription>{description}</SettingDescription>}
+            </SettingContent>
+        </SettingRow>
+    </SettingItem>
+);
 
-const Settings: React.FC = () => {
-    return <div>Settings</div>;
+const SelectSetting: React.FC<SelectSettingProps> = ({
+    label,
+    description,
+    value,
+    options,
+    onChange,
+}) => (
+    <SettingItem>
+        <SettingRow>
+            <SettingContent>
+                <SettingLabel>
+                    {label}:
+                    <SettingControl>
+                        <Select value={value} onChange={(e) => onChange(e.target.value)}>
+                            {options.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </SettingControl>
+                </SettingLabel>
+                {description && <SettingDescription>{description}</SettingDescription>}
+            </SettingContent>
+        </SettingRow>
+    </SettingItem>
+);
+
+const Settings: React.FC<SettingsProps> = ({ className }) => {
+    const [settings, setSettings] = useState<UserSettings>({
+        notifications: {
+            wateringReminders: true,
+            careNotifications: true,
+            emailNotifications: false,
+        },
+        display: {
+            theme: 'light',
+            language: 'en',
+            dateFormat: 'MM/DD/YYYY',
+        },
+        care: {
+            defaultWateringFrequency: 7,
+            reminderTime: '09:00',
+            weekStartsOn: 'sunday',
+        },
+    });
+
+    const updateNotificationSetting = (key: keyof UserSettings['notifications'], value: boolean) => {
+        setSettings(prev => ({
+            ...prev,
+            notifications: {
+                ...prev.notifications,
+                [key]: value,
+            },
+        }));
+    };
+
+    const updateDisplaySetting = (key: keyof UserSettings['display'], value: string) => {
+        setSettings(prev => ({
+            ...prev,
+            display: {
+                ...prev.display,
+                [key]: value,
+            },
+        }));
+    };
+
+    const updateCareSetting = (key: keyof UserSettings['care'], value: string | number) => {
+        setSettings(prev => ({
+            ...prev,
+            care: {
+                ...prev.care,
+                [key]: value,
+            },
+        }));
+    };
+
+    const handleExportData = () => {
+        // TODO: Implement data export functionality
+        console.log('Export data clicked');
+    };
+
+    const handleImportData = () => {
+        // TODO: Implement data import functionality
+        console.log('Import data clicked');
+    };
+
+    const handleResetData = () => {
+        // TODO: Implement data reset functionality
+        if (confirm('Are you sure you want to reset all data? This action cannot be undone.')) {
+            console.log('Reset data confirmed');
+        }
+    };
+
+    return (
+        <SettingsContainer className={className}>
+            <SettingsHeader>
+                <h1>Settings</h1>
+                <p>Customize your Plant Manager experience and preferences.</p>
+            </SettingsHeader>
+
+            <SettingsSections>
+                <SettingsSection>
+                    <h3>🔔 Notifications</h3>
+                    <ToggleSetting
+                        label="Enable watering reminders"
+                        description="Get notified when your plants need watering"
+                        checked={settings.notifications.wateringReminders}
+                        onChange={(value) => updateNotificationSetting('wateringReminders', value)}
+                    />
+                    <ToggleSetting
+                        label="Enable care notifications"
+                        description="Receive alerts for fertilizing, repotting, and other care tasks"
+                        checked={settings.notifications.careNotifications}
+                        onChange={(value) => updateNotificationSetting('careNotifications', value)}
+                    />
+                    <ToggleSetting
+                        label="Email notifications"
+                        description="Receive care reminders via email"
+                        checked={settings.notifications.emailNotifications}
+                        onChange={(value) => updateNotificationSetting('emailNotifications', value)}
+                    />
+                </SettingsSection>
+
+                <SettingsSection>
+                    <h3>🎨 Display & Preferences</h3>
+                    <SelectSetting
+                        label="Theme"
+                        description="Choose your preferred color scheme"
+                        value={settings.display.theme}
+                        options={[
+                            { value: 'light', label: 'Light' },
+                            { value: 'dark', label: 'Dark' },
+                            { value: 'auto', label: 'Auto (System)' },
+                        ]}
+                        onChange={(value) => updateDisplaySetting('theme', value)}
+                    />
+                    <SelectSetting
+                        label="Language"
+                        description="Select your preferred language"
+                        value={settings.display.language}
+                        options={[
+                            { value: 'en', label: 'English' },
+                            { value: 'es', label: 'Español' },
+                            { value: 'fr', label: 'Français' },
+                            { value: 'de', label: 'Deutsch' },
+                        ]}
+                        onChange={(value) => updateDisplaySetting('language', value)}
+                    />
+                    <SelectSetting
+                        label="Date Format"
+                        description="Choose how dates are displayed"
+                        value={settings.display.dateFormat}
+                        options={[
+                            { value: 'MM/DD/YYYY', label: 'MM/DD/YYYY' },
+                            { value: 'DD/MM/YYYY', label: 'DD/MM/YYYY' },
+                            { value: 'YYYY-MM-DD', label: 'YYYY-MM-DD' },
+                        ]}
+                        onChange={(value) => updateDisplaySetting('dateFormat', value)}
+                    />
+                </SettingsSection>
+
+                <SettingsSection>
+                    <h3>🌱 Care Settings</h3>
+                    <SelectSetting
+                        label="Default watering frequency"
+                        description="Default days between watering for new plants"
+                        value={settings.care.defaultWateringFrequency.toString()}
+                        options={[
+                            { value: '1', label: 'Daily' },
+                            { value: '3', label: 'Every 3 days' },
+                            { value: '7', label: 'Weekly' },
+                            { value: '14', label: 'Bi-weekly' },
+                            { value: '30', label: 'Monthly' },
+                        ]}
+                        onChange={(value) => updateCareSetting('defaultWateringFrequency', parseInt(value))}
+                    />
+                    <SelectSetting
+                        label="Reminder time"
+                        description="What time should we send you care reminders?"
+                        value={settings.care.reminderTime}
+                        options={[
+                            { value: '07:00', label: '7:00 AM' },
+                            { value: '09:00', label: '9:00 AM' },
+                            { value: '12:00', label: '12:00 PM' },
+                            { value: '18:00', label: '6:00 PM' },
+                            { value: '20:00', label: '8:00 PM' },
+                        ]}
+                        onChange={(value) => updateCareSetting('reminderTime', value)}
+                    />
+                    <SelectSetting
+                        label="Week starts on"
+                        description="First day of the week in calendar views"
+                        value={settings.care.weekStartsOn}
+                        options={[
+                            { value: 'sunday', label: 'Sunday' },
+                            { value: 'monday', label: 'Monday' },
+                        ]}
+                        onChange={(value) => updateCareSetting('weekStartsOn', value)}
+                    />
+                </SettingsSection>
+
+                <SettingsSection>
+                    <h3>💾 Data Management</h3>
+                    <SettingItem>
+                        <p style={{ marginBottom: '1rem', color: '#666' }}>
+                            Export your plant data for backup or import data from another device.
+                        </p>
+                        <DataActionsContainer>
+                            <ActionButton variant="primary" onClick={handleExportData}>
+                                📤 Export Plant Data
+                            </ActionButton>
+                            <ActionButton variant="secondary" onClick={handleImportData}>
+                                📥 Import Plant Data
+                            </ActionButton>
+                            <ActionButton variant="danger" onClick={handleResetData}>
+                                🗑️ Reset All Data
+                            </ActionButton>
+                        </DataActionsContainer>
+                    </SettingItem>
+                </SettingsSection>
+            </SettingsSections>
+        </SettingsContainer>
+    );
 };
 
 export default Settings;

--- a/src/pages/Settings/Settings.types.tsx
+++ b/src/pages/Settings/Settings.types.tsx
@@ -1,0 +1,42 @@
+export interface SettingsProps {
+  className?: string;
+}
+
+export interface SettingSectionProps {
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export interface ToggleSettingProps {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export interface SelectSettingProps {
+  label: string;
+  description?: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+}
+
+export interface UserSettings {
+  notifications: {
+    wateringReminders: boolean;
+    careNotifications: boolean;
+    emailNotifications: boolean;
+  };
+  display: {
+    theme: 'light' | 'dark' | 'auto';
+    language: string;
+    dateFormat: string;
+  };
+  care: {
+    defaultWateringFrequency: number;
+    reminderTime: string;
+    weekStartsOn: 'sunday' | 'monday';
+  };
+}


### PR DESCRIPTION
## Summary
- restore Settings page with previous functionality
- add styled components for the Settings page
- define types for settings options

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f4eb822748328af831765aabc20f6