### PR TITLE
Create sticky PageHeader and use across pages

### DIFF
--- a/src/components/PageHeader/PageHeader.styles.tsx
+++ b/src/components/PageHeader/PageHeader.styles.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+import { theme } from '../../theme';
+
+export const Container = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${theme.spacing.md} 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: ${theme.colors.background};
+  border-bottom: 1px solid ${theme.colors.border};
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  margin-bottom: ${theme.spacing.md};
+`;
+
+export const Title = styled.h1`
+  font-size: ${theme.fontSize['2xl']};
+  font-weight: ${theme.fontWeight.bold};
+  margin: 0;
+`;
+
+export const Subtitle = styled.p`
+  font-size: ${theme.fontSize.sm};
+  color: ${theme.colors.text.secondary};
+  margin: ${theme.spacing.xs} 0 0 0;
+`;
+
+export const Left = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+`;
+
+export const Right = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+`;
+
+export const BackButton = styled.button`
+  background: none;
+  border: none;
+  padding: ${theme.spacing.sm};
+  margin-left: -${theme.spacing.sm};
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: ${theme.colors.text.primary};
+`;

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ChevronLeft } from 'lucide-react';
+import type { PageHeaderProps } from './PageHeader.types';
+import { Container, Title, Subtitle, Left, Right, BackButton } from './PageHeader.styles';
+
+const PageHeader: React.FC<PageHeaderProps> = ({
+  title,
+  subtitle,
+  onBack,
+  rightContent,
+  className,
+}) => {
+  return (
+    <Container className={className}>
+      <Left>
+        {onBack && (
+          <BackButton onClick={onBack} aria-label="Go back">
+            <ChevronLeft size={20} />
+          </BackButton>
+        )}
+        {title && typeof title === 'string' ? <Title>{title}</Title> : title}
+        {subtitle && <Subtitle>{subtitle}</Subtitle>}
+      </Left>
+      {rightContent && <Right>{rightContent}</Right>}
+    </Container>
+  );
+};
+
+export default PageHeader;

--- a/src/components/PageHeader/PageHeader.types.tsx
+++ b/src/components/PageHeader/PageHeader.types.tsx
@@ -1,0 +1,7 @@
+export interface PageHeaderProps {
+  title?: string | React.ReactNode;
+  subtitle?: string;
+  onBack?: () => void;
+  rightContent?: React.ReactNode;
+  className?: string;
+}

--- a/src/components/PageHeader/index.ts
+++ b/src/components/PageHeader/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PageHeader';
+export type { PageHeaderProps } from './PageHeader.types';

--- a/src/pages/Add/Add.styles.tsx
+++ b/src/pages/Add/Add.styles.tsx
@@ -7,39 +7,6 @@ export const AddContainer = styled.div`
   padding-bottom: 100px; // Bottom navigation space
 `;
 
-export const HeaderContainer = styled.div`
-  position: sticky;
-  top: 0;
-  background-color: ${theme.colors.background};
-  z-index: 100;
-  padding: ${theme.spacing.md} 0;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  border-bottom: 1px solid ${theme.colors.border};
-  margin-bottom: ${theme.spacing.md};
-`;
-
-export const BackButton = styled.button`
-  background: none;
-  border: none;
-  display: flex;
-  align-items: center;
-  padding: ${theme.spacing.sm};
-  margin-left: -${theme.spacing.sm};
-  color: ${theme.colors.text.primary};
-  cursor: pointer;
-  font-weight: ${theme.fontWeight.medium};
-  
-  svg {
-    margin-right: ${theme.spacing.xs};
-  }
-`;
-
-export const PageTitle = styled.h1`
-  font-size: ${theme.fontSize['2xl']};
-  font-weight: ${theme.fontWeight.bold};
-  margin: ${theme.spacing.md} 0;
-  color: ${theme.colors.text.primary};
-`;
 
 export const FormSection = styled.div`
   background: ${theme.colors.background};

--- a/src/pages/Add/Add.tsx
+++ b/src/pages/Add/Add.tsx
@@ -1,12 +1,9 @@
 import React, { useState } from 'react';
-import { Camera, ScanText, ChevronLeft, Droplets } from 'lucide-react';
+import { Camera, ScanText, Droplets } from 'lucide-react';
 import { Select } from 'antd';
 import styled from 'styled-components';
 import {
     AddContainer,
-    HeaderContainer,
-    BackButton,
-    PageTitle,
     FormSection,
     PhotoSection,
     PhotoPlaceholder,
@@ -25,6 +22,7 @@ import {
 } from './Add.styles';
 import type { AddPlantProps, WateringFrequency, PotSize, Location } from './Add.types';
 import type { Plant } from '../../types';
+import PageHeader from '../../components/PageHeader';
 
 // Styled Ant Design Select components
 const StyledSelect = styled(Select)`
@@ -132,16 +130,11 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
 
         // Reset form or navigate away
         console.log('Plant added:', newPlant);
-    };    return (
+    };
+
+    return (
         <AddContainer className={className}>
-            <HeaderContainer>
-                <BackButton onClick={handleGoBack}>
-                    <ChevronLeft size={20} />
-                    Back
-                </BackButton>
-                
-                <PageTitle>Add New Plant</PageTitle>
-            </HeaderContainer>
+            <PageHeader title="Add New Plant" onBack={handleGoBack} />
 
             <form onSubmit={handleSubmit}>
                 <PhotoSection>

--- a/src/pages/Dashboard/Dashboard.styles.tsx
+++ b/src/pages/Dashboard/Dashboard.styles.tsx
@@ -5,14 +5,6 @@ export const DashboardContainer = styled.div`
   max-width: 100%;
 `;
 
-export const PageHeader = styled.div`
-  border-bottom: 1px solid ${theme.colors.border};
-  margin-bottom: ${theme.spacing.lg};
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  background-color: ${theme.colors.background};
-`;
 
 export const PageTitle = styled.h1`
   font-size: ${theme.fontSize['2xl']};

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import { Select } from 'antd';
 import {
     DashboardContainer,
-    PageHeader,
     PageTitle,
     PlantCount,
     SearchSection,
@@ -23,6 +22,7 @@ import {
 } from './Dashboard.styles';
 import type { DashboardProps } from './Dashboard.types';
 import { plants } from '../../mocks';
+import PageHeader from '../../components/PageHeader';
 
 const Dashboard: React.FC<DashboardProps> = ({ className }) => {
     const [searchTerm, setSearchTerm] = useState('');
@@ -67,12 +67,14 @@ const Dashboard: React.FC<DashboardProps> = ({ className }) => {
         }
 
         return matchesSearch && matchesFilter;
-    }); return (
+    });
+
+    return (
         <DashboardContainer className={className}>
-            <PageHeader>
-                <PageTitle>My Plants</PageTitle>
-                <PlantCount>{filteredPlants.length} of {plants.length} plants</PlantCount>
-            </PageHeader>
+            <PageHeader
+                title={<PageTitle>My Plants</PageTitle>}
+                rightContent={<PlantCount>{filteredPlants.length} of {plants.length} plants</PlantCount>}
+            />
 
             <SearchSection>
                 <SearchInput>

--- a/src/pages/PlantDetail/PlantDetail.styles.tsx
+++ b/src/pages/PlantDetail/PlantDetail.styles.tsx
@@ -6,36 +6,6 @@ export const PlantDetailContainer = styled.div`
   padding: 0 16px 80px 16px;
 `;
 
-export const HeaderContainer = styled.div`
-  display: flex;
-  align-items: center;
-  padding: 16px 0;
-  position: sticky;
-  top: 0;
-  background: ${({ theme }) => theme.colors.background};
-  z-index: 100;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
-  margin-bottom: 8px;
-`;
-
-export const BackButton = styled.button`
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 8px;
-  margin-right: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: ${({ theme }) => theme.colors.text.primary};
-`;
-
-export const PageTitle = styled.h1`
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin: 0;
-`;
 
 export const ProfileCard = styled.div`
   background: white;

--- a/src/pages/PlantDetail/PlantDetail.tsx
+++ b/src/pages/PlantDetail/PlantDetail.tsx
@@ -1,11 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Droplet, Clock, Book, BarChart2, Settings } from 'lucide-react';
+import { Droplet, Clock, Book, BarChart2, Settings } from 'lucide-react';
 import {
     PlantDetailContainer,
-    HeaderContainer,
-    BackButton,
-    PageTitle,
     ProfileCard,
     PlantInfo,
     PlantImage,
@@ -40,6 +37,7 @@ import {
 import type { PlantDetailProps, WateringHistoryItemProps } from './PlantDetail.types';
 import { plants } from '../../mocks/plants';
 import type { Plant } from '../../types';
+import PageHeader from '../../components/PageHeader';
 
 const formatDate = (date: Date): string => {
     return date.toISOString().split('T')[0];
@@ -125,12 +123,7 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
 
     return (
         <PlantDetailContainer className={className}>
-            <HeaderContainer>
-                <BackButton onClick={handleBack}>
-                    <ArrowLeft size={24} />
-                </BackButton>
-                <PageTitle>{plant.name}</PageTitle>
-            </HeaderContainer>
+            <PageHeader title={plant.name} onBack={handleBack} />
 
             <ProfileCard>
                 <PlantInfo>

--- a/src/pages/Settings/index.ts
+++ b/src/pages/Settings/index.ts
@@ -1,8 +1,1 @@
 export { default } from './Settings';
-export type { 
-  SettingsProps, 
-  SettingSectionProps, 
-  ToggleSettingProps, 
-  SelectSettingProps, 
-  UserSettings 
-} from './Settings.types';


### PR DESCRIPTION
## Summary
- create reusable `PageHeader` component
- replace page specific headers with the new component
- tidy old style files and fix `Settings` export

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f4f25d5e88328a74af13e07171315