### PR TITLE
Add internationalization support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "antd": "^5.25.4",
+        "i18next": "^25.2.1",
         "lucide-react": "^0.511.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-i18next": "^15.5.2",
         "react-router-dom": "^7.6.1",
         "styled-components": "^6.1.18"
       },
@@ -2910,6 +2912,46 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.2.1.tgz",
+      "integrity": "sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4016,6 +4058,32 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.2.tgz",
+      "integrity": "sha512-ePODyXgmZQAOYTbZXQn5rRsSBu3Gszo69jxW6aKmlSgxKAI1fOhDwSu6bT4EKHciWPKQ7v7lPrjeiadR6Gi+1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4434,7 +4502,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4609,6 +4677,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   },
   "dependencies": {
     "antd": "^5.25.4",
+    "i18next": "^25.2.1",
     "lucide-react": "^0.511.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-i18next": "^15.5.2",
     "react-router-dom": "^7.6.1",
     "styled-components": "^6.1.18"
   },

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import {
     CalendarContainer,
@@ -18,6 +19,7 @@ const Calendar: React.FC<CalendarProps> = ({
     onDateSelect, 
     tasks = [] 
 }) => {
+    const { t } = useTranslation();
     const [currentDate, setCurrentDate] = useState(selectedDate || new Date());
 
     const generateCalendar = () => {
@@ -31,7 +33,7 @@ const Calendar: React.FC<CalendarProps> = ({
         const today = new Date();
 
         // Add day headers
-        const dayHeaders = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        const dayHeaders = t('calendar.daysShort', { returnObjects: true }) as string[];
         dayHeaders.forEach(day => {
             days.push(
                 <CalendarDayHeader key={`header-${day}`}>
@@ -87,10 +89,7 @@ const Calendar: React.FC<CalendarProps> = ({
         setCurrentDate(newDate);
     };
 
-    const monthNames = [
-        'January', 'February', 'March', 'April', 'May', 'June',
-        'July', 'August', 'September', 'October', 'November', 'December'
-    ];
+    const monthNames = t('calendar.months', { returnObjects: true }) as string[];
 
     return (
         <CalendarContainer className={className}>

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Home, Calendar, Plus, Settings } from 'lucide-react';
 import {
     NavigationWrapper,
@@ -10,14 +11,15 @@ import {
 } from './Navigation.styles';
 import type { NavLinkItemProps, NavigationProps } from './Navigation.types';
 
-const navItems: NavLinkItemProps[] = [
-    { to: '/', icon: Home, label: 'Dashboard' },
-    { to: '/care', icon: Calendar, label: 'Calendar' },
-    { to: '/add', icon: Plus, label: 'Add' },
-    { to: '/settings', icon: Settings, label: 'Settings' },
-];
+const navItems = [
+    { to: '/', icon: Home, labelKey: 'navigation.dashboard' },
+    { to: '/care', icon: Calendar, labelKey: 'navigation.calendar' },
+    { to: '/add', icon: Plus, labelKey: 'navigation.add' },
+    { to: '/settings', icon: Settings, labelKey: 'navigation.settings' },
+] as const satisfies NavLinkItemProps[];
 
 const Navigation: React.FC<NavigationProps> = ({ className }) => {
+    const { t } = useTranslation();
     return (
         <NavigationWrapper className={className}>
             <NavigationContainer>
@@ -33,7 +35,7 @@ const Navigation: React.FC<NavigationProps> = ({ className }) => {
                                 <IconContainer>
                                     <IconComponent size={24} />
                                 </IconContainer>
-                                <LabelText>{item.label}</LabelText>
+                                <LabelText>{t(item.labelKey)}</LabelText>
                             </StyledNavLink>
                         </NavLinkItem>
                     );

--- a/src/components/Navigation/Navigation.types.tsx
+++ b/src/components/Navigation/Navigation.types.tsx
@@ -8,5 +8,5 @@ export interface NavigationProps {
 export interface NavLinkItemProps {
   to: string;
   icon: ComponentType<LucideProps>;
-  label: string;
+  labelKey: string;
 }

--- a/src/components/Task/Task.tsx
+++ b/src/components/Task/Task.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Droplets, Circle, CheckCircle2, Scissors, Flower } from 'lucide-react';
 import {
     TaskItem,
@@ -28,6 +29,7 @@ const Task: React.FC<TaskProps> = ({
     onComplete,
     className,
 }) => {
+    const { t } = useTranslation();
     const handleComplete = () => {
         if (onComplete) {
             onComplete(id);
@@ -40,9 +42,9 @@ const Task: React.FC<TaskProps> = ({
         tomorrow.setDate(tomorrow.getDate() + 1);
 
         if (date.toDateString() === today.toDateString()) {
-            return 'Today';
+            return t('task.today');
         } else if (date.toDateString() === tomorrow.toDateString()) {
-            return 'Tomorrow';
+            return t('task.tomorrow');
         } else {
             return date.toLocaleDateString('en-US', {
                 month: 'short',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,25 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en.json';
+import es from './locales/es.json';
+
+const getInitialLanguage = () => {
+  if (typeof navigator !== 'undefined') {
+    return navigator.language.startsWith('es') ? 'es' : 'en';
+  }
+  return 'en';
+};
+
+void i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      es: { translation: es },
+    },
+    lng: getInitialLanguage(),
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  });
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,73 @@
+{
+  "navigation": {
+    "dashboard": "Dashboard",
+    "calendar": "Calendar",
+    "add": "Add",
+    "settings": "Settings"
+  },
+  "dashboard": {
+    "title": "My Plants",
+    "plantCount": "{{count}} of {{total}} plants",
+    "searchPlaceholder": "Search plants...",
+    "filterPlaceholder": "Filter plants",
+    "filter": {
+      "all": "All Plants",
+      "healthy": "Healthy",
+      "needsAttention": "Needs Attention",
+      "sick": "Sick",
+      "watering": "Needs Watering"
+    },
+    "noWatering": "No watering scheduled",
+    "noPlants": "No plants match your current filters."
+  },
+  "add": {
+    "back": "Back",
+    "title": "Add New Plant",
+    "takePhoto": "Take Photo",
+    "scanPlant": "Scan Plant",
+    "plantSpecies": "Plant Species",
+    "speciesPlaceholder": "Select or search species",
+    "plantNickname": "Plant Nickname",
+    "giveNickname": "Give your plant a name",
+    "potSize": "Pot Size",
+    "selectSize": "Select size",
+    "location": "Location",
+    "selectRoom": "Select room",
+    "careNotes": "Care Notes",
+    "addInstructions": "Add any special care instructions...",
+    "wateringFrequency": "Watering Frequency",
+    "selectFrequency": "Select frequency",
+    "pushNotifications": "Push Notifications",
+    "savePlant": "Save Plant"
+  },
+  "care": {
+    "title": "Care Schedule",
+    "subtitle": "Keep track of your plant care routine",
+    "todaysTasks": "Today's Tasks",
+    "upcomingTasks": "Upcoming Tasks",
+    "emptyToday": "No care tasks scheduled for today. Great job keeping up with your plants!",
+    "emptyUpcoming": "No upcoming care tasks. Add some plants to get started!"
+  },
+  "plantDetail": {
+    "nextWatering": "Next Watering",
+    "frequency": "Frequency",
+    "plantHealth": "Plant Health",
+    "careNotes": "Care Notes",
+    "wateringHistory": "Watering History",
+    "waterNow": "Water Now",
+    "editPlant": "Edit Plant",
+    "notSet": "Not set",
+    "loading": "Loading..."
+  },
+  "task": {
+    "today": "Today",
+    "tomorrow": "Tomorrow"
+  },
+  "calendar": {
+    "months": ["January","February","March","April","May","June","July","August","September","October","November","December"],
+    "daysShort": ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"]
+  },
+  "settings": {
+    "title": "Settings"
+  }
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,73 @@
+{
+  "navigation": {
+    "dashboard": "Inicio",
+    "calendar": "Calendario",
+    "add": "Añadir",
+    "settings": "Ajustes"
+  },
+  "dashboard": {
+    "title": "Mis Plantas",
+    "plantCount": "{{count}} de {{total}} plantas",
+    "searchPlaceholder": "Buscar plantas...",
+    "filterPlaceholder": "Filtrar plantas",
+    "filter": {
+      "all": "Todas las plantas",
+      "healthy": "Saludables",
+      "needsAttention": "Con atención",
+      "sick": "Enfermas",
+      "watering": "Necesitan riego"
+    },
+    "noWatering": "Sin riego programado",
+    "noPlants": "Ninguna planta coincide con tus filtros."
+  },
+  "add": {
+    "back": "Volver",
+    "title": "Añadir planta",
+    "takePhoto": "Tomar foto",
+    "scanPlant": "Escanear planta",
+    "plantSpecies": "Especie de la planta",
+    "speciesPlaceholder": "Selecciona o busca especie",
+    "plantNickname": "Apodo de la planta",
+    "giveNickname": "Ponle un nombre a tu planta",
+    "potSize": "Tamaño de maceta",
+    "selectSize": "Selecciona tamaño",
+    "location": "Ubicación",
+    "selectRoom": "Selecciona lugar",
+    "careNotes": "Notas de cuidado",
+    "addInstructions": "Agrega instrucciones especiales...",
+    "wateringFrequency": "Frecuencia de riego",
+    "selectFrequency": "Selecciona frecuencia",
+    "pushNotifications": "Notificaciones push",
+    "savePlant": "Guardar planta"
+  },
+  "care": {
+    "title": "Agenda de cuidados",
+    "subtitle": "Lleva el control del cuidado de tus plantas",
+    "todaysTasks": "Tareas de hoy",
+    "upcomingTasks": "Próximas tareas",
+    "emptyToday": "No hay tareas de cuidado para hoy. ¡Buen trabajo!",
+    "emptyUpcoming": "No hay próximas tareas. ¡Agrega algunas plantas!"
+  },
+  "plantDetail": {
+    "nextWatering": "Próximo riego",
+    "frequency": "Frecuencia",
+    "plantHealth": "Salud de la planta",
+    "careNotes": "Notas de cuidado",
+    "wateringHistory": "Historial de riego",
+    "waterNow": "Regar ahora",
+    "editPlant": "Editar planta",
+    "notSet": "Sin definir",
+    "loading": "Cargando..."
+  },
+  "task": {
+    "today": "Hoy",
+    "tomorrow": "Mañana"
+  },
+  "calendar": {
+    "months": ["Enero","Febrero","Marzo","Abril","Mayo","Junio","Julio","Agosto","Septiembre","Octubre","Noviembre","Diciembre"],
+    "daysShort": ["Dom","Lun","Mar","Mié","Jue","Vie","Sáb"]
+  },
+  "settings": {
+    "title": "Ajustes"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import 'antd/dist/reset.css'
+import './i18n'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/src/pages/Add/Add.tsx
+++ b/src/pages/Add/Add.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Camera, ScanText, ChevronLeft, Droplets } from 'lucide-react';
 import { Select } from 'antd';
 import styled from 'styled-components';
@@ -82,6 +83,7 @@ const locations: Location[] = [
 ];
 
 const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
+    const { t } = useTranslation();
     // Form state
     const [plantSpecies, setPlantSpecies] = useState('');
     const [nickname, setNickname] = useState('');
@@ -137,10 +139,10 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
             <HeaderContainer>
                 <BackButton onClick={handleGoBack}>
                     <ChevronLeft size={20} />
-                    Back
+                    {t('add.back')}
                 </BackButton>
                 
-                <PageTitle>Add New Plant</PageTitle>
+                <PageTitle>{t('add.title')}</PageTitle>
             </HeaderContainer>
 
             <form onSubmit={handleSubmit}>
@@ -165,18 +167,19 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
                     <PhotoActions>
                         <PhotoButton type="button" onClick={handleTakePhoto}>
                             <Camera size={18} />
-                            Take Photo
+                            {t('add.takePhoto')}
                         </PhotoButton>
                         <PhotoButton type="button" onClick={handleScanPlant}>
                             <ScanText size={18} />
-                            Scan Plant
+                            {t('add.scanPlant')}
                         </PhotoButton>
                     </PhotoActions>
                 </PhotoSection>
-
-                <FormSection>                    <FormGroup>
-                        <Label htmlFor="species">Plant Species</Label>                        <StyledSelect
-                            placeholder="Select or search species"
+                <FormSection>
+                    <FormGroup>
+                        <Label htmlFor="species">{t('add.plantSpecies')}</Label>
+                        <StyledSelect
+                            placeholder={t('add.speciesPlaceholder')}
                             value={plantSpecies}
                             onChange={(value) => setPlantSpecies(value as string)}
                             showSearch
@@ -194,19 +197,21 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
                     </FormGroup>
 
                     <FormGroup>
-                        <Label htmlFor="nickname">Plant Nickname</Label>
+                        <Label htmlFor="nickname">{t('add.plantNickname')}</Label>
                         <Input
                             id="nickname"
                             type="text"
-                            placeholder="Give your plant a name"
+                            placeholder={t('add.giveNickname')}
                             value={nickname}
                             onChange={(e) => setNickname(e.target.value)}
                         />
                     </FormGroup>
 
-                    <FormRow>                        <FormGroup>
-                            <Label htmlFor="potSize">Pot Size</Label>                            <StyledSelect
-                                placeholder="Select size"
+                    <FormRow>
+                        <FormGroup>
+                            <Label htmlFor="potSize">{t('add.potSize')}</Label>
+                            <StyledSelect
+                                placeholder={t('add.selectSize')}
                                 value={potSize}
                                 onChange={(value) => setPotSize(value as string)}
                                 options={potSizes}
@@ -214,9 +219,9 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
                         </FormGroup>
 
                         <FormGroup>
-                            <Label htmlFor="location">Location</Label>
+                            <Label htmlFor="location">{t('add.location')}</Label>
                             <StyledSelect
-                                placeholder="Select room"
+                                placeholder={t('add.selectRoom')}
                                 value={location}
                                 onChange={(value) => setLocation(value as string)}
                                 options={locations}
@@ -225,10 +230,10 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
                     </FormRow>
 
                     <FormGroup>
-                        <Label htmlFor="careNotes">Care Notes</Label>
+                        <Label htmlFor="careNotes">{t('add.careNotes')}</Label>
                         <Textarea
                             id="careNotes"
-                            placeholder="Add any special care instructions..."
+                            placeholder={t('add.addInstructions')}
                             value={careNotes}
                             onChange={(e) => setCareNotes(e.target.value)}
                         />
@@ -238,10 +243,11 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
                 <FormSection>
                     <WateringScheduleIcon>
                         <Droplets />
-                    </WateringScheduleIcon>                    <FormGroup>
-                        <Label htmlFor="wateringFrequency">Watering Frequency</Label>
+                    </WateringScheduleIcon>
+                    <FormGroup>
+                        <Label htmlFor="wateringFrequency">{t('add.wateringFrequency')}</Label>
                         <StyledSelect
-                            placeholder="Select frequency"
+                            placeholder={t('add.selectFrequency')}
                             value={wateringFrequency}
                             onChange={(value) => setWateringFrequency(value as string)}
                             options={wateringFrequencies}
@@ -250,7 +256,7 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
 
                     <FormGroup>
                         <ToggleRow>
-                            <Label htmlFor="notifications">Push Notifications</Label>
+                            <Label htmlFor="notifications">{t('add.pushNotifications')}</Label>
                             <Toggle>
                                 <input
                                     type="checkbox"
@@ -263,7 +269,7 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
                     </FormGroup>
                 </FormSection>
 
-                <SaveButton type="submit">Save Plant</SaveButton>
+                <SaveButton type="submit">{t('add.savePlant')}</SaveButton>
             </form>
         </AddContainer>
     );

--- a/src/pages/Care/Care.tsx
+++ b/src/pages/Care/Care.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Calendar from '../../components/Calendar';
 import Task from '../../components/Task';
@@ -45,6 +46,7 @@ const EmptyTasks: React.FC<{ message: string }> = ({ message }) => (
 );
 
 const Care: React.FC<CareProps> = ({ className }) => {
+    const { t } = useTranslation();
     const [completedTasks, setCompletedTasks] = useState<Set<string>>(new Set());
     const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
 
@@ -83,7 +85,7 @@ const Care: React.FC<CareProps> = ({ className }) => {
 
     return (
         <CareContainer className={className}>
-            <Header title="Care Schedule" subtitle="Keep track of your plant care routine" />
+            <Header title={t('care.title')} subtitle={t('care.subtitle')} />
 
             <Calendar 
                 selectedDate={selectedDate}
@@ -92,7 +94,8 @@ const Care: React.FC<CareProps> = ({ className }) => {
             />
 
             <TasksSection>
-                <SectionTitle>Today's Tasks</SectionTitle>                <TasksList>
+                <SectionTitle>{t('care.todaysTasks')}</SectionTitle>
+                <TasksList>
                     {todayTasks.length > 0 ? (
                         todayTasks.map(task => (
                             <Task
@@ -103,13 +106,14 @@ const Care: React.FC<CareProps> = ({ className }) => {
                             />
                         ))
                     ) : (
-                        <EmptyTasks message="No care tasks scheduled for today. Great job keeping up with your plants!" />
+                        <EmptyTasks message={t('care.emptyToday')} />
                     )}
                 </TasksList>
             </TasksSection>
 
             <TasksSection>
-                <SectionTitle>Upcoming Tasks</SectionTitle>                <TasksList>
+                <SectionTitle>{t('care.upcomingTasks')}</SectionTitle>
+                <TasksList>
                     {upcomingTasks.length > 0 ? (
                         upcomingTasks.map(task => (
                             <Task
@@ -120,7 +124,7 @@ const Care: React.FC<CareProps> = ({ className }) => {
                             />
                         ))
                     ) : (
-                        <EmptyTasks message="No upcoming care tasks. Add some plants to get started!" />
+                        <EmptyTasks message={t('care.emptyUpcoming')} />
                     )}
                 </TasksList>
             </TasksSection>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Search, Clock, MapPin, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Select } from 'antd';
@@ -25,17 +26,18 @@ import type { DashboardProps } from './Dashboard.types';
 import { plants } from '../../mocks';
 
 const Dashboard: React.FC<DashboardProps> = ({ className }) => {
+    const { t } = useTranslation();
     const [searchTerm, setSearchTerm] = useState('');
     const [selectedFilter, setSelectedFilter] = useState<string>('All');
     const navigate = useNavigate();
 
     // Available filter options
     const filterOptions = [
-        { value: 'All', label: 'All Plants' },
-        { value: 'healthy', label: 'Healthy' },
-        { value: 'needsAttention', label: 'Needs Attention' },
-        { value: 'sick', label: 'Sick' },
-        { value: 'watering', label: 'Needs Watering' }
+        { value: 'All', label: t('dashboard.filter.all') },
+        { value: 'healthy', label: t('dashboard.filter.healthy') },
+        { value: 'needsAttention', label: t('dashboard.filter.needsAttention') },
+        { value: 'sick', label: t('dashboard.filter.sick') },
+        { value: 'watering', label: t('dashboard.filter.watering') },
     ];
 
     // Apply both search and filter
@@ -70,8 +72,8 @@ const Dashboard: React.FC<DashboardProps> = ({ className }) => {
     }); return (
         <DashboardContainer className={className}>
             <PageHeader>
-                <PageTitle>My Plants</PageTitle>
-                <PlantCount>{filteredPlants.length} of {plants.length} plants</PlantCount>
+                <PageTitle>{t('dashboard.title')}</PageTitle>
+                <PlantCount>{t('dashboard.plantCount', { count: filteredPlants.length, total: plants.length })}</PlantCount>
             </PageHeader>
 
             <SearchSection>
@@ -79,7 +81,7 @@ const Dashboard: React.FC<DashboardProps> = ({ className }) => {
                     <Search className="search-icon" size={20} />
                     <input
                         type="text"
-                        placeholder="Search plants..."
+                        placeholder={t('dashboard.searchPlaceholder')}
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
                     />
@@ -95,7 +97,7 @@ const Dashboard: React.FC<DashboardProps> = ({ className }) => {
                         value={selectedFilter}
                         onChange={setSelectedFilter}
                         options={filterOptions}
-                        placeholder="Filter plants"
+                        placeholder={t('dashboard.filterPlaceholder')}
                     />
                 </FilterContainer>
             </SearchSection>
@@ -113,7 +115,7 @@ const Dashboard: React.FC<DashboardProps> = ({ className }) => {
                                 <PlantMeta>
                                     <MetaItem>
                                         <Clock size={14} />
-                                        {plant.nextWatering?.toDateString() || 'No watering scheduled'}
+                                        {plant.nextWatering?.toDateString() || t('dashboard.noWatering')}
                                     </MetaItem>
                                     <MetaItem>
                                         <MapPin size={14} />
@@ -125,7 +127,7 @@ const Dashboard: React.FC<DashboardProps> = ({ className }) => {
                         </PlantCard>
                     ))
                 ) : (
-                    <span>No plants match your current filters.</span>
+                    <span>{t('dashboard.noPlants')}</span>
                 )}
             </PlantsGrid>
         </DashboardContainer>

--- a/src/pages/PlantDetail/PlantDetail.tsx
+++ b/src/pages/PlantDetail/PlantDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Droplet, Clock, Book, BarChart2, Settings } from 'lucide-react';
 import {
@@ -40,6 +41,7 @@ import {
 import type { PlantDetailProps, WateringHistoryItemProps } from './PlantDetail.types';
 import { plants } from '../../mocks/plants';
 import type { Plant } from '../../types';
+import i18n from '../../i18n';
 
 const formatDate = (date: Date): string => {
     return date.toISOString().split('T')[0];
@@ -51,9 +53,9 @@ const getRelativeWateringDay = (lastWatered: Date): string => {
     tomorrow.setDate(tomorrow.getDate() + 1);
 
     if (formatDate(lastWatered) === formatDate(today)) {
-        return 'Today';
+        return i18n.t('task.today');
     } else if (formatDate(lastWatered) === formatDate(tomorrow)) {
-        return 'Tomorrow';
+        return i18n.t('task.tomorrow');
     } else {
         return formatDate(lastWatered);
     }
@@ -72,6 +74,7 @@ const WateringHistoryItem: React.FC<WateringHistoryItemProps> = ({ date, descrip
 );
 
 const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
+    const { t } = useTranslation();
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const [plant, setPlant] = useState<Plant | null>(null);
@@ -98,7 +101,7 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
     }, [id]);
 
     if (!plant) {
-        return <div>Loading...</div>;
+        return <div>{t('plantDetail.loading')}</div>;
     }
 
     const handleBack = () => {
@@ -118,7 +121,7 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
     // Determine next watering day (simplified logic for demo)
     const nextWateringDay = plant.lastWatered
         ? getRelativeWateringDay(new Date(plant.lastWatered.getTime() + 5 * 24 * 60 * 60 * 1000))
-        : 'Not set';
+        : t('plantDetail.notSet');
 
     // Health percentage (mock value for demo)
     const healthPercentage = 92;
@@ -149,7 +152,7 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
 
                 <HealthSection>
                     <HealthLabel>
-                        <span>Plant Health</span>
+                        <span>{t('plantDetail.plantHealth')}</span>
                         <span>{healthPercentage}%</span>
                     </HealthLabel>
                     <HealthBar>
@@ -163,14 +166,14 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
                     <InfoIconWrapper>
                         <Droplet size={24} />
                     </InfoIconWrapper>
-                    <InfoLabel>Next Watering</InfoLabel>
+                    <InfoLabel>{t('plantDetail.nextWatering')}</InfoLabel>
                     <InfoValue>{nextWateringDay}</InfoValue>
                 </InfoCard>
                 <InfoCard>
                     <InfoIconWrapper>
                         <Clock size={24} />
                     </InfoIconWrapper>
-                    <InfoLabel>Frequency</InfoLabel>
+                    <InfoLabel>{t('plantDetail.frequency')}</InfoLabel>
                     <InfoValue>Every 5 days</InfoValue>
                 </InfoCard>
             </InfoCardsContainer>
@@ -180,7 +183,7 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
                     <SectionIcon>
                         <Book size={20} />
                     </SectionIcon>
-                    <SectionTitle>Care Notes</SectionTitle>
+                    <SectionTitle>{t('plantDetail.careNotes')}</SectionTitle>
                 </SectionHeader>
                 <CareNotesText>
                     Produces baby plants. Great for beginners.
@@ -192,7 +195,7 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
                     <SectionIcon>
                         <BarChart2 size={20} />
                     </SectionIcon>
-                    <SectionTitle>Watering History</SectionTitle>
+                    <SectionTitle>{t('plantDetail.wateringHistory')}</SectionTitle>
                 </SectionHeader>
                 <HistoryList>
                     {wateringHistory.map((item, index) => (
@@ -208,11 +211,11 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
             <ActionButtonsContainer>
                 <WaterNowButton onClick={handleWaterNow}>
                     <Droplet size={20} />
-                    Water Now
+                    {t('plantDetail.waterNow')}
                 </WaterNowButton>
                 <EditPlantButton onClick={handleEditPlant}>
                     <Settings size={20} />
-                    Edit Plant
+                    {t('plantDetail.editPlant')}
                 </EditPlantButton>
             </ActionButtonsContainer>
         </PlantDetailContainer>

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 
 const Settings: React.FC = () => {
-    return <div>Settings</div>;
+    const { t } = useTranslation();
+    return <div>{t('settings.title')}</div>;
 };
 
 export default Settings;

--- a/src/pages/Settings/index.ts
+++ b/src/pages/Settings/index.ts
@@ -1,8 +1,1 @@
 export { default } from './Settings';
-export type { 
-  SettingsProps, 
-  SettingSectionProps, 
-  ToggleSettingProps, 
-  SelectSettingProps, 
-  UserSettings 
-} from './Settings.types';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,6 +14,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "resolveJsonModule": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- integrate `i18next` and `react-i18next`
- add English and Spanish translation files
- translate navigation and pages
- update calendar and task components for i18n
- update tsconfig for JSON modules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f4fb16120832881497243e0057d39