### PR TITLE
Add AppData provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-route
 import { AnimatePresence, motion } from 'framer-motion';
 import { GlobalStyles } from './styles/GlobalStyles';
 import { CustomThemeProvider } from './theme/ThemeContext';
+import { AppDataProvider } from './context';
 import { AppContainer, MainContent } from './App.styles';
 import Navigation from './components/Navigation';
 import Dashboard from './pages/Dashboard';
@@ -43,15 +44,17 @@ function AnimatedRoutes() {
 function App() {
   return (
     <CustomThemeProvider>
-      <GlobalStyles />
-      <Router>
-        <AppContainer>
-          <MainContent>
-            <AnimatedRoutes />
-          </MainContent>
-          <Navigation />
-        </AppContainer>
-      </Router>
+      <AppDataProvider>
+        <GlobalStyles />
+        <Router>
+          <AppContainer>
+            <MainContent>
+              <AnimatedRoutes />
+            </MainContent>
+            <Navigation />
+          </AppContainer>
+        </Router>
+      </AppDataProvider>
     </CustomThemeProvider>
   );
 }

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -1,0 +1,106 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { Plant } from '../types';
+import type { UserSettings } from '../pages/Settings/Settings.types';
+import { plants as mockPlants } from '../mocks';
+
+interface AppDataContextValue {
+  plants: Plant[];
+  addPlant: (plant: Plant) => void;
+  updatePlant: (id: string, updated: Partial<Plant>) => void;
+  settings: UserSettings;
+  updateNotificationSetting: (key: keyof UserSettings['notifications'], value: boolean) => void;
+  updateDisplaySetting: (key: keyof UserSettings['display'], value: string) => void;
+  updateCareSetting: (key: keyof UserSettings['care'], value: string | number) => void;
+}
+
+const AppDataContext = createContext<AppDataContextValue>({
+  plants: [],
+  addPlant: () => {},
+  updatePlant: () => {},
+  settings: {
+    notifications: { wateringReminders: true, careNotifications: true, emailNotifications: false },
+    display: { theme: 'light', language: 'en', dateFormat: 'MM/DD/YYYY' },
+    care: { defaultWateringFrequency: 7, reminderTime: '09:00', weekStartsOn: 'sunday' },
+  },
+  updateNotificationSetting: () => {},
+  updateDisplaySetting: () => {},
+  updateCareSetting: () => {},
+});
+
+export const useAppData = () => useContext(AppDataContext);
+
+export const AppDataProvider = ({ children }: { children: ReactNode }) => {
+  const [plants, setPlants] = useState<Plant[]>(mockPlants);
+  const [settings, setSettings] = useState<UserSettings>({
+    notifications: {
+      wateringReminders: true,
+      careNotifications: true,
+      emailNotifications: false,
+    },
+    display: {
+      theme: 'light',
+      language: 'en',
+      dateFormat: 'MM/DD/YYYY',
+    },
+    care: {
+      defaultWateringFrequency: 7,
+      reminderTime: '09:00',
+      weekStartsOn: 'sunday',
+    },
+  });
+
+  const addPlant = (plant: Plant) => {
+    setPlants(prev => [...prev, plant]);
+  };
+
+  const updatePlant = (id: string, updated: Partial<Plant>) => {
+    setPlants(prev => prev.map(p => (p.id === id ? { ...p, ...updated } : p)));
+  };
+
+  const updateNotificationSetting = (
+    key: keyof UserSettings['notifications'],
+    value: boolean,
+  ) => {
+    setSettings(prev => ({
+      ...prev,
+      notifications: { ...prev.notifications, [key]: value },
+    }));
+  };
+
+  const updateDisplaySetting = (
+    key: keyof UserSettings['display'],
+    value: string,
+  ) => {
+    setSettings(prev => ({
+      ...prev,
+      display: { ...prev.display, [key]: value },
+    }));
+  };
+
+  const updateCareSetting = (
+    key: keyof UserSettings['care'],
+    value: string | number,
+  ) => {
+    setSettings(prev => ({
+      ...prev,
+      care: { ...prev.care, [key]: value },
+    }));
+  };
+
+  return (
+    <AppDataContext.Provider
+      value={{
+        plants,
+        addPlant,
+        updatePlant,
+        settings,
+        updateNotificationSetting,
+        updateDisplaySetting,
+        updateCareSetting,
+      }}
+    >
+      {children}
+    </AppDataContext.Provider>
+  );
+};

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,1 @@
+export { AppDataProvider, useAppData } from './AppDataContext';

--- a/src/pages/Add/Add.tsx
+++ b/src/pages/Add/Add.tsx
@@ -26,6 +26,7 @@ import {
 } from './Add.styles';
 import type { AddPlantProps, WateringFrequency, PotSize, Location } from './Add.types';
 import type { Plant } from '../../types';
+import { useAppData } from '../../context';
 
 // Styled Ant Design Select components
 const StyledSelect = styled(Select)`
@@ -78,6 +79,7 @@ const locations: Location[] = [
 
 const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
     const { t } = useTranslation();
+    const { addPlant } = useAppData();
     // Form state
     const [plantSpecies, setPlantSpecies] = useState('');
     const [nickname, setNickname] = useState('');
@@ -132,6 +134,8 @@ const AddPlant: React.FC<AddPlantProps> = ({ className, onSave, onCancel }) => {
 
         if (onSave) {
             onSave(newPlant);
+        } else {
+            addPlant(newPlant);
         }
 
         // Reset form or navigate away

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -23,12 +23,13 @@ import {
     FilterContainer,
 } from './Dashboard.styles';
 import type { DashboardProps } from './Dashboard.types';
-import { plants } from '../../mocks';
+import { useAppData } from '../../context';
 
 const Dashboard: React.FC<DashboardProps> = ({ className }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const [selectedFilter, setSelectedFilter] = useState<string>('All');
     const navigate = useNavigate();
+    const { plants } = useAppData();
 
     // Available filter options
     const { t } = useTranslation();

--- a/src/pages/PlantDetail/PlantDetail.tsx
+++ b/src/pages/PlantDetail/PlantDetail.tsx
@@ -39,7 +39,7 @@ import {
     EditPlantButton
 } from './PlantDetail.styles';
 import type { PlantDetailProps, WateringHistoryItemProps } from './PlantDetail.types';
-import { plants } from '../../mocks/plants';
+import { useAppData } from '../../context';
 import type { Plant } from '../../types';
 
 const formatDate = (date: Date): string => {
@@ -76,6 +76,7 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
     const { t } = useTranslation();
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
+    const { plants } = useAppData();
     const [plant, setPlant] = useState<Plant | null>(null);
 
     // Simulated watering history
@@ -91,13 +92,11 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
     ];
 
     useEffect(() => {
-        // In a real app, fetch the plant from an API
-        // For now, use the mock data
         const foundPlant = plants.find(p => p.id === id);
         if (foundPlant) {
             setPlant(foundPlant);
         }
-    }, [id]);
+    }, [id, plants]);
 
     if (!plant) {
         return <div>{t('Loading')}</div>;

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     SettingsContainer,
@@ -16,8 +16,9 @@ import {
     SettingContent,
     SettingControl,
 } from './Settings.styles';
-import type { ToggleSettingProps, SelectSettingProps, SettingsProps, UserSettings } from './Settings.types';
+import type { ToggleSettingProps, SelectSettingProps, SettingsProps } from './Settings.types';
 import { useTheme } from '../../theme/ThemeContext';
+import { useAppData } from '../../context';
 
 
 const ToggleSetting: React.FC<ToggleSettingProps> = ({
@@ -72,60 +73,14 @@ const SelectSetting: React.FC<SelectSettingProps> = ({
 
 const Settings: React.FC<SettingsProps> = ({ className }) => {
     const { t, i18n } = useTranslation();
-    const { themeName, setTheme } = useTheme();
-    const [settings, setSettings] = useState<UserSettings>({
-        notifications: {
-            wateringReminders: true,
-            careNotifications: true,
-            emailNotifications: false,
-        },
-        display: {
-            theme: themeName,
-            language: i18n.language,
-            dateFormat: 'MM/DD/YYYY',
-        },
-        care: {
-            defaultWateringFrequency: 7,
-            reminderTime: '09:00',
-            weekStartsOn: 'sunday',
-        },
-    });
+    const { setTheme } = useTheme();
+    const {
+        settings,
+        updateNotificationSetting,
+        updateDisplaySetting,
+        updateCareSetting,
+    } = useAppData();
 
-    const updateNotificationSetting = (key: keyof UserSettings['notifications'], value: boolean) => {
-        setSettings(prev => ({
-            ...prev,
-            notifications: {
-                ...prev.notifications,
-                [key]: value,
-            },
-        }));
-    };
-
-    const updateDisplaySetting = (key: keyof UserSettings['display'], value: string) => {
-        if (key === 'language') {
-            i18n.changeLanguage(value);
-        }
-        setSettings(prev => ({
-            ...prev,
-            display: {
-                ...prev.display,
-                [key]: value,
-            },
-        }));
-        if (key === 'theme' && (value === 'light' || value === 'dark')) {
-            setTheme(value);
-        }
-    };
-
-    const updateCareSetting = (key: keyof UserSettings['care'], value: string | number) => {
-        setSettings(prev => ({
-            ...prev,
-            care: {
-                ...prev.care,
-                [key]: value,
-            },
-        }));
-    };
 
     const handleExportData = () => {
         // TODO: Implement data export functionality
@@ -185,7 +140,12 @@ const Settings: React.FC<SettingsProps> = ({ className }) => {
                             { value: 'dark', label: t('Dark') },
                             { value: 'auto', label: t('Auto') },
                         ]}
-                        onChange={(value) => updateDisplaySetting('theme', value)}
+                        onChange={(value) => {
+                            updateDisplaySetting('theme', value);
+                            if (value === 'light' || value === 'dark') {
+                                setTheme(value);
+                            }
+                        }}
                     />
                     <SelectSetting
                         label={t('Language')}
@@ -195,7 +155,10 @@ const Settings: React.FC<SettingsProps> = ({ className }) => {
                             { value: 'en', label: t('English') },
                             { value: 'es', label: t('Spanish') },
                         ]}
-                        onChange={(value) => updateDisplaySetting('language', value)}
+                        onChange={(value) => {
+                            i18n.changeLanguage(value);
+                            updateDisplaySetting('language', value);
+                        }}
                     />
                     <SelectSetting
                         label={t('DateFormat')}


### PR DESCRIPTION
## Summary
- store plant data and settings in a new context provider
- wrap the application in the provider
- use the provider in Dashboard, Add, PlantDetail and Settings pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684078a35f308328a75281d8a10c6a9e