### PR TITLE
Refactor pages to share UI components

### DIFF
--- a/src/components/Common/BackButton.tsx
+++ b/src/components/Common/BackButton.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const BackButton = styled.button`
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  padding: ${({ theme }) => theme.spacing.sm};
+  color: ${({ theme }) => theme.colors.text.primary};
+  cursor: pointer;
+
+  svg {
+    margin-right: ${({ theme }) => theme.spacing.xs};
+  }
+`;

--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -1,0 +1,65 @@
+import styled, { css } from 'styled-components';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
+
+export const Button = styled.button<{ variant?: ButtonVariant }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${({ theme }) => theme.spacing.xs};
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  font-size: ${({ theme }) => theme.fontSize.base};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  transition: background-color ${({ theme }) => theme.transitions.fast};
+  border: none;
+  cursor: pointer;
+
+  ${({ variant = 'ghost', theme }) => {
+    switch (variant) {
+      case 'primary':
+        return css`
+          background-color: ${theme.colors.primary};
+          color: ${theme.colors.text.white};
+
+          &:hover {
+            background-color: ${theme.colors.primaryHover};
+          }
+        `;
+      case 'secondary':
+        return css`
+          background-color: ${theme.colors.secondary};
+          color: ${theme.colors.text.white};
+
+          &:hover {
+            background-color: ${theme.colors.secondaryHover};
+          }
+        `;
+      case 'danger':
+        return css`
+          background-color: #dc3545;
+          color: ${theme.colors.text.white};
+
+          &:hover {
+            background-color: #c82333;
+          }
+        `;
+      case 'ghost':
+      default:
+        return css`
+          background-color: transparent;
+          color: ${theme.colors.text.primary};
+          border: 1px solid ${theme.colors.border};
+
+          &:hover {
+            background-color: ${theme.colors.border};
+          }
+        `;
+    }
+  }}
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/Common/Card.tsx
+++ b/src/components/Common/Card.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Card = styled.div`
+  background: ${({ theme }) => theme.colors.background};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  padding: ${({ theme }) => theme.spacing.lg};
+  box-shadow: ${({ theme }) => theme.shadows.sm};
+`;

--- a/src/components/Common/FormElements.tsx
+++ b/src/components/Common/FormElements.tsx
@@ -1,0 +1,74 @@
+import styled from 'styled-components';
+import { Select as AntSelect } from 'antd';
+
+export const Input = styled.input`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  font-size: ${({ theme }) => theme.fontSize.base};
+  background: ${({ theme }) => theme.colors.surface};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.light};
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+export const Textarea = styled.textarea`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  font-size: ${({ theme }) => theme.fontSize.base};
+  min-height: 100px;
+  resize: vertical;
+  background: ${({ theme }) => theme.colors.surface};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.light};
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+export const Select = styled(AntSelect)`
+  width: 100%;
+
+  .ant-select-selector {
+    height: 48px !important;
+    border-radius: ${({ theme }) => theme.borderRadius.md} !important;
+    border-color: ${({ theme }) => theme.colors.border} !important;
+    background: ${({ theme }) => theme.colors.surface} !important;
+    color: ${({ theme }) => theme.colors.text.primary} !important;
+
+    .ant-select-selection-item {
+      line-height: 46px !important;
+      font-size: ${({ theme }) => theme.fontSize.base};
+      color: ${({ theme }) => theme.colors.text.primary};
+    }
+
+    .ant-select-selection-placeholder {
+      line-height: 46px !important;
+      color: ${({ theme }) => theme.colors.text.light};
+    }
+
+    &:hover {
+      border-color: ${({ theme }) => theme.colors.primary} !important;
+    }
+  }
+
+  &.ant-select-focused .ant-select-selector {
+    border-color: ${({ theme }) => theme.colors.primary} !important;
+    box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.primary}33 !important;
+  }
+`;

--- a/src/components/Common/Titles.tsx
+++ b/src/components/Common/Titles.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const PageTitle = styled.h1`
+  font-size: ${({ theme }) => theme.fontSize['2xl']};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin: 0 0 ${({ theme }) => theme.spacing.md} 0;
+`;
+
+export const SectionTitle = styled.h3`
+  font-size: ${({ theme }) => theme.fontSize.lg};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin: 0 0 ${({ theme }) => theme.spacing.md} 0;
+`;

--- a/src/components/Common/index.ts
+++ b/src/components/Common/index.ts
@@ -1,0 +1,5 @@
+export * from './Button';
+export * from './Titles';
+export * from './BackButton';
+export * from './Card';
+export * from './FormElements';

--- a/src/pages/Add/Add.styles.tsx
+++ b/src/pages/Add/Add.styles.tsx
@@ -1,4 +1,11 @@
 import styled from 'styled-components';
+import {
+  BackButton as BaseBackButton,
+  PageTitle as BasePageTitle,
+  Input as BaseInput,
+  Textarea as BaseTextarea,
+  Button,
+} from '../../components/Common';
 
 export const AddContainer = styled.div`
   max-width: 100%;
@@ -17,27 +24,13 @@ export const HeaderContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing.md};
 `;
 
-export const BackButton = styled.button`
-  background: none;
-  border: none;
-  display: flex;
-  align-items: center;
-  padding: ${({ theme }) => theme.spacing.sm};
+export const BackButton = styled(BaseBackButton)`
   margin-left: -${({ theme }) => theme.spacing.sm};
-  color: ${({ theme }) => theme.colors.text.primary};
-  cursor: pointer;
   font-weight: ${({ theme }) => theme.fontWeight.medium};
-  
-  svg {
-    margin-right: ${({ theme }) => theme.spacing.xs};
-  }
 `;
 
-export const PageTitle = styled.h1`
-  font-size: ${({ theme }) => theme.fontSize['2xl']};
-  font-weight: ${({ theme }) => theme.fontWeight.bold};
+export const PageTitle = styled(BasePageTitle)`
   margin: ${({ theme }) => theme.spacing.md} 0;
-  color: ${({ theme }) => theme.colors.text.primary};
 `;
 
 export const FormSection = styled.div`
@@ -113,24 +106,7 @@ export const Label = styled.label`
   color: ${({ theme }) => theme.colors.text.primary};
 `;
 
-export const Input = styled.input`
-  width: 100%;
-  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
-  border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
-  font-size: ${({ theme }) => theme.fontSize.base};
-  background: ${({ theme }) => theme.colors.surface};
-  color: ${({ theme }) => theme.colors.text.primary};
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.text.light};
-  }
-  
-  &:focus {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.primary};
-  }
-`;
+export const Input = styled(BaseInput)``;
 
 export const Select = styled.button`
   width: 100%;
@@ -151,26 +127,8 @@ export const Select = styled.button`
   }
 `;
 
-export const Textarea = styled.textarea`
-  width: 100%;
-  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
-  border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
-  font-size: ${({ theme }) => theme.fontSize.base};
-  min-height: 100px;
-  resize: vertical;
+export const Textarea = styled(BaseTextarea)`
   font-family: inherit;
-  background: ${({ theme }) => theme.colors.surface};
-  color: ${({ theme }) => theme.colors.text.primary};
-  
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.text.light};
-  }
-  
-  &:focus {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.primary};
-  }
 `;
 
 export const FormRow = styled.div`
@@ -236,23 +194,7 @@ export const ToggleSlider = styled.span<{ checked?: boolean }>`
   }
 `;
 
-export const SaveButton = styled.button`
+export const SaveButton = styled(Button).attrs({ variant: 'primary' })`
   width: 100%;
-  padding: ${({ theme }) => theme.spacing.md};
-  background-color: ${({ theme }) => theme.colors.primary};
-  color: white;
-  border: none;
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
-  font-weight: ${({ theme }) => theme.fontWeight.semibold};
   margin-top: ${({ theme }) => theme.spacing.xl};
-  cursor: pointer;
-  
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.primaryHover};
-  }
-  
-  &:disabled {
-    background-color: ${({ theme }) => theme.colors.border};
-    cursor: not-allowed;
-  }
 `;

--- a/src/pages/Care/Care.styles.tsx
+++ b/src/pages/Care/Care.styles.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { SectionTitle as BaseSectionTitle } from '../../components/Common';
 
 export const CareContainer = styled.div`
   max-width: 100%;
@@ -10,10 +11,7 @@ export const TasksSection = styled.section`
   margin-bottom: ${({ theme }) => theme.spacing.xl};
 `;
 
-export const SectionTitle = styled.h3`
-  font-size: ${({ theme }) => theme.fontSize.lg};
-  font-weight: ${({ theme }) => theme.fontWeight.semibold};
-  color: ${({ theme }) => theme.colors.text.primary};
+export const SectionTitle = styled(BaseSectionTitle)`
   margin: 0 0 ${({ theme }) => theme.spacing.md} 0;
 `;
 

--- a/src/pages/Dashboard/Dashboard.styles.tsx
+++ b/src/pages/Dashboard/Dashboard.styles.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { PageTitle as BasePageTitle } from '../../components/Common';
 
 export const DashboardContainer = styled.div`
   max-width: 100%;
@@ -13,10 +14,7 @@ export const PageHeader = styled.div`
   background-color: ${({ theme }) => theme.colors.background};
 `;
 
-export const PageTitle = styled.h1`
-  font-size: ${({ theme }) => theme.fontSize['2xl']};
-  font-weight: ${({ theme }) => theme.fontWeight.bold};
-  color: ${({ theme }) => theme.colors.text.primary};
+export const PageTitle = styled(BasePageTitle)`
   margin: 0 0 ${({ theme }) => theme.spacing.xs} 0;
 `;
 

--- a/src/pages/PlantDetail/PlantDetail.styles.tsx
+++ b/src/pages/PlantDetail/PlantDetail.styles.tsx
@@ -1,4 +1,11 @@
 import styled from 'styled-components';
+import {
+  BackButton as BaseBackButton,
+  PageTitle as BasePageTitle,
+  SectionTitle as BaseSectionTitle,
+  Button,
+  Card,
+} from '../../components/Common';
 
 export const PlantDetailContainer = styled.div`
   display: flex;
@@ -19,30 +26,17 @@ export const HeaderContainer = styled.div`
   margin-bottom: 8px;
 `;
 
-export const BackButton = styled.button`
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 8px;
+export const BackButton = styled(BaseBackButton)`
   margin-right: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: ${({ theme }) => theme.colors.text.primary};
 `;
 
-export const PageTitle = styled.h1`
-  font-size: 1.5rem;
-  font-weight: 600;
+export const PageTitle = styled(BasePageTitle)`
   margin: 0;
+  font-size: 1.5rem;
 `;
 
-export const ProfileCard = styled.div`
-  background: white;
-  border-radius: 12px;
-  padding: 16px;
+export const ProfileCard = styled(Card)`
   margin-bottom: 16px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 `;
 
 export const PlantInfo = styled.div`
@@ -128,14 +122,10 @@ export const InfoCardsContainer = styled.div`
   margin-bottom: 16px;
 `;
 
-export const InfoCard = styled.div`
-  background: white;
-  border-radius: 12px;
-  padding: 16px;
+export const InfoCard = styled(Card)`
   display: flex;
   flex-direction: column;
   align-items: center;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 `;
 
 export const InfoIconWrapper = styled.div`
@@ -155,12 +145,8 @@ export const InfoValue = styled.p`
   margin: 4px 0 0 0;
 `;
 
-export const SectionCard = styled.div`
-  background: white;
-  border-radius: 12px;
-  padding: 16px;
+export const SectionCard = styled(Card)`
   margin-bottom: 16px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 `;
 
 export const SectionHeader = styled.div`
@@ -174,9 +160,8 @@ export const SectionIcon = styled.span`
   color: ${({ theme }) => theme.colors.primary};
 `;
 
-export const SectionTitle = styled.h3`
+export const SectionTitle = styled(BaseSectionTitle)`
   font-size: 1rem;
-  font-weight: 600;
   margin: 0;
 `;
 
@@ -226,30 +211,16 @@ export const ActionButtonsContainer = styled.div`
   margin-bottom: 16px;
 `;
 
-export const WaterNowButton = styled.button`
-  background-color: #2196f3;
-  color: white;
-  border: none;
+export const WaterNowButton = styled(Button).attrs({ variant: 'primary' })`
   border-radius: 8px;
   padding: 12px;
   font-weight: 600;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   gap: 8px;
 `;
 
-export const EditPlantButton = styled.button`
-  background-color: white;
-  color: ${({ theme }) => theme.colors.text.primary};
-  border: 1px solid ${({ theme }) => theme.colors.border};
+export const EditPlantButton = styled(Button)`
   border-radius: 8px;
   padding: 12px;
   font-weight: 600;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   gap: 8px;
 `;

--- a/src/pages/Settings/Settings.styles.tsx
+++ b/src/pages/Settings/Settings.styles.tsx
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
+import { Button } from '../../components/Common';
 
 
 export const SettingsContainer = styled.div`
@@ -119,69 +120,9 @@ export const DataActionsContainer = styled.div`
   }
 `;
 
-export const ActionButton = styled.button<{ variant?: 'primary' | 'secondary' | 'danger' }>`
+export const ActionButton = styled(Button)<{ variant?: 'primary' | 'secondary' | 'danger' }>`
   padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.lg};
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
-  font-size: ${({ theme }) => theme.fontSize.base};
-  font-weight: ${({ theme }) => theme.fontWeight.medium};
-  transition: all ${({ theme }) => theme.transitions.fast};
   min-width: 160px;
-
-  ${({ variant, theme }) =>
-    variant === 'primary' &&
-    css`
-      background-color: ${theme.colors.primary};
-      color: ${theme.colors.text.white};
-
-      &:hover {
-        background-color: ${theme.colors.primaryHover};
-      }
-    `}
-
-  ${({ variant, theme }) =>
-    variant === 'secondary' &&
-    css`
-      background-color: ${theme.colors.secondary};
-      color: ${theme.colors.text.white};
-
-      &:hover {
-        background-color: ${theme.colors.secondaryHover};
-      }
-    `}
-
-  ${({ variant, theme }) =>
-    variant === 'danger' &&
-    css`
-      background-color: #dc3545;
-      color: ${theme.colors.text.white};
-
-      &:hover {
-        background-color: #c82333;
-      }
-    `}
-
-  ${({ variant, theme }) =>
-    !variant &&
-    css`
-      background-color: ${theme.colors.surface};
-      color: ${theme.colors.text.primary};
-      border: 1px solid ${theme.colors.border};
-
-      &:hover {
-        background-color: ${theme.colors.border};
-      }
-    `}
-
-  &:focus {
-    outline: 2px solid ${({ theme }) => theme.colors.primary};
-
-    outline-offset: 2px;
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
 `;
 
 export const SettingRow = styled.div`


### PR DESCRIPTION
## Summary
- build shared UI component library under `components/Common`
- replace duplicate `PageTitle`, `SectionTitle`, `BackButton`, and form elements with shared versions
- use shared `Button` and `Card` components across pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68407855188083289e343da9657e7a56