### PR TITLE
Implementar transiciones de navegación según la dirección

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { GlobalStyles } from './styles/GlobalStyles';
@@ -12,19 +13,51 @@ import PlantDetail from './pages/PlantDetail';
 import Settings from './pages/Settings';
 import PromptButton from './components/PromptButton';
 
+const bottomMenuRoutes = ['/', '/care', '/add', '/settings'];
+
+type Direction = 'left' | 'right' | 'up';
+
 const pageVariants = {
-  initial: { x: '100%', opacity: 0 },
-  animate: { x: 0, opacity: 1 },
-  exit: { x: '-100%', opacity: 0 },
+  initial: (direction: Direction) => ({
+    x: direction === 'left' ? '-100%' : direction === 'right' ? '100%' : 0,
+    y: direction === 'up' ? '100%' : 0,
+    opacity: 0,
+  }),
+  animate: { x: 0, y: 0, opacity: 1 },
+  exit: { opacity: 0 },
 };
 
 function AnimatedRoutes() {
   const location = useLocation();
+  const prevPathRef = React.useRef(location.pathname);
+
+  const getBasePath = (path: string) => {
+    if (path === '/') return '/';
+    const segments = path.split('/');
+    return `/${segments[1] || ''}`;
+  };
+
+  const getDirection = (from: string, to: string): Direction => {
+    const fromIndex = bottomMenuRoutes.indexOf(getBasePath(from));
+    const toIndex = bottomMenuRoutes.indexOf(getBasePath(to));
+    if (fromIndex !== -1 && toIndex !== -1) {
+      if (toIndex > fromIndex) return 'right';
+      if (toIndex < fromIndex) return 'left';
+    }
+    return 'up';
+  };
+
+  const direction = getDirection(prevPathRef.current, location.pathname);
+
+  React.useEffect(() => {
+    prevPathRef.current = location.pathname;
+  }, [location.pathname]);
   return (
     <AnimatePresence mode="wait">
       <motion.div
         key={location.pathname}
         variants={pageVariants}
+        custom={direction}
         initial="initial"
         animate="animate"
         exit="exit"


### PR DESCRIPTION
## Summary
- calcular la dirección de navegación basándonos en el orden del menú inferior
- mover las páginas laterales de forma acorde (izquierda, derecha o desde abajo)
- fijar la salida de las páginas con efecto de opacidad

## Testing
- `npm install`
- `npm run lint` *(falla: variables sin usar en Settings)*
- `npm run build` *(falla: variables sin usar en Settings)*

------
https://chatgpt.com/codex/tasks/task_e_68431efdc6688328a110a5cff414c31d