### PR TITLE
Remove desktop specific styles

### DIFF
--- a/src/App.styles.tsx
+++ b/src/App.styles.tsx
@@ -19,11 +19,4 @@ export const MainContent = styled.main`
   /* Add a small top padding on mobile for pages without sticky headers */
   padding-top: ${({ theme }) => theme.spacing.md};
 
-  @media (min-width: ${({ theme }) => theme.breakpoints.tablet}) {
-    max-width: 600px;
-    margin: 0 auto;
-    padding: 0 ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.xl};
-    padding-bottom: calc(80px + ${({ theme }) => theme.spacing.xl});
-    padding-top: ${({ theme }) => theme.spacing.md};
-  }
 `;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,13 +90,7 @@ function AnimatedRoutes() {
         animate="animate"
         exit="exit"
         transition={{ duration: 0.15, ease: "easeInOut" }}
-        style={{
-          position: 'absolute',
-          width: '100%',
-          height: '100%',
-          top: 0,
-          left: 0,
-        }}
+        style={{ width: '100%', height: '100%' }}
       >
         <Routes location={location}>
           <Route path="/" element={<Dashboard />} />

--- a/src/pages/Dashboard/Dashboard.styles.tsx
+++ b/src/pages/Dashboard/Dashboard.styles.tsx
@@ -98,12 +98,6 @@ export const PlantCard = styled.div`
     transform: scale(0.98);
   }
   
-  @media (min-width: ${({ theme }) => theme.breakpoints.tablet}) {
-    &:hover {
-      box-shadow: ${({ theme }) => theme.shadows.md};
-      transform: translateY(-1px);
-    }
-  }
 `;
 
 export const PlantAvatar = styled.div`


### PR DESCRIPTION
## Summary
- remove width/padding overrides from `MainContent`
- remove hover-only styling from `PlantCard`

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6843ff5637b88328ab19ce044d107415