### PR TITLE
Add loading screen for auth initialization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import PlantDetail from './pages/PlantDetail';
 import Settings from './pages/Settings';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
+import LoadingPage from './pages/Loading';
 import PromptButton from './components/PromptButton';
 
 const navPaths = ['/', '/care', '/add', '/settings'] as const;
@@ -115,7 +116,10 @@ function AuthRoutes() {
 }
 
 function RootApp() {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
+  if (loading) {
+    return <LoadingPage />;
+  }
   if (!user) {
     return <AuthRoutes />;
   }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ import {
 
 interface AuthContextValue {
   user: User | null;
+  loading: boolean;
   login: (email: string, password: string) => Promise<boolean>;
   register: (email: string, password: string) => Promise<boolean>;
   logout: () => Promise<void>;
@@ -18,6 +19,7 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
+  loading: true,
   login: async () => false,
   register: async () => false,
   logout: async () => { },
@@ -27,9 +29,13 @@ export const useAuth = () => useContext(AuthContext);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsub = onAuthStateChanged(auth, current => setUser(current));
+    const unsub = onAuthStateChanged(auth, current => {
+      setUser(current);
+      setLoading(false);
+    });
     return unsub;
   }, []);
 
@@ -56,7 +62,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Loading/Loading.styles.tsx
+++ b/src/pages/Loading/Loading.styles.tsx
@@ -1,0 +1,44 @@
+import styled, { keyframes } from 'styled-components';
+import { PageTitle as BasePageTitle } from '../../components/Common';
+import { Loader as LoaderIcon } from 'lucide-react';
+
+export const Container = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  padding: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const IconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  svg {
+    width: 64px;
+    height: 64px;
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+export const Title = styled(BasePageTitle)`
+  text-align: center;
+`;
+
+const spin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const Spinner = styled(LoaderIcon)`
+  width: 48px;
+  height: 48px;
+  color: ${({ theme }) => theme.colors.primary};
+  animation: ${spin} 1s linear infinite;
+`;
+
+export const LoadingText = styled.p`
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;

--- a/src/pages/Loading/Loading.tsx
+++ b/src/pages/Loading/Loading.tsx
@@ -1,0 +1,19 @@
+import { Sprout } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Container, IconWrapper, Spinner, Title, LoadingText } from './Loading.styles';
+
+const Loading = () => {
+  const { t } = useTranslation();
+  return (
+    <Container>
+      <IconWrapper>
+        <Sprout />
+      </IconWrapper>
+      <Title>{t('AppName')}</Title>
+      <Spinner />
+      <LoadingText>{t('Loading')}</LoadingText>
+    </Container>
+  );
+};
+
+export default Loading;

--- a/src/pages/Loading/index.ts
+++ b/src/pages/Loading/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Loading';


### PR DESCRIPTION
## Summary
- add full screen Loading page with spinner and app icon
- expose `loading` from `AuthContext`
- show loading page in `App` while checking auth state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68440f6d1b70832898a9c00b71fec76a