### PR TITLE
Add camera upload and AI plant scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A comprehensive home plant management application built with React, TypeScript, 
 - **Plant Inventory**: Add, edit, and organize your plant collection with detailed profiles
 - **Plant Identification**: Track plant names (common and scientific), species, and varieties
 - **Photo Gallery**: Upload and manage photos of your plants to track their growth
+- **AI Plant Scan**: Take or upload a photo and let ChatGPT suggest the plant name
 - **Plant Categories**: Organize plants by type (houseplants, succulents, herbs, etc.)
 
 ### Care Scheduling & Reminders
@@ -132,6 +133,12 @@ VITE_FIREBASE_PROJECT_ID=your_project_id
 VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
 VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
+```
+
+To enable plant identification when scanning photos, create a ChatGPT API key and add it to the `.env` file:
+
+```bash
+VITE_OPENAI_API_KEY=your_openai_key
 ```
 
 The `useFirestore` hook in `src/hooks/useFirestore.ts` provides simple `get`, `post` and `put` helpers for interacting with Cloud Firestore collections.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "i18next": "^23.8.1",
         "i18next-browser-languagedetector": "^7.0.1",
         "lucide-react": "^0.511.0",
+        "openai": "^5.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-i18next": "^13.0.0",
@@ -4074,6 +4075,27 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.1.1.tgz",
+      "integrity": "sha512-lgIdLqvpLpz8xPUKcEIV6ml+by74mbSBz8zv/AHHebtLn/WdpH4kdXT3/Q5uUKDHg3vHV/z9+G9wZINRX6rkDg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "i18next": "^23.8.1",
     "i18next-browser-languagedetector": "^7.0.1",
     "lucide-react": "^0.511.0",
+    "openai": "^5.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^13.0.0",


### PR DESCRIPTION
## Summary
- support uploading plant images from device or camera
- send scanned plant image to ChatGPT to autofill form
- document OpenAI key and feature in README

## Testing
- `npm run lint` *(fails: react code issues)*
- `npx tsc -p tsconfig.app.json`
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68440fd2c4048328b66d1d34d76791b0