### PR TITLE
Hide unused features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import { AppDataProvider, AuthProvider, useAuth } from './context';
 import { AppContainer, MainContent } from './App.styles';
 import Navigation from './components/Navigation';
 import Dashboard from './pages/Dashboard';
-import Care from './pages/Care';
 import AddPlant from './pages/Add';
 import PlantDetail from './pages/PlantDetail';
 import Settings from './pages/Settings';
@@ -16,7 +15,7 @@ import Signup from './pages/Signup';
 import LoadingPage from './pages/Loading';
 import PromptButton from './components/PromptButton';
 
-const navPaths = ['/', '/care', '/add', '/settings'] as const;
+const navPaths = ['/', '/add', '/settings'] as const;
 
 type Direction = 'left' | 'right' | 'up' | 'down';
 
@@ -98,7 +97,6 @@ function AnimatedRoutes() {
           <Route path="/plants/:id" element={<PlantDetail />} />
           <Route path="/plants/:id/edit" element={<AddPlant />} />
           <Route path="/add" element={<AddPlant />} />
-          <Route path="/care" element={<Care />} />
           <Route path="/settings" element={<Settings />} />
         </Routes>
       </motion.div>

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Home, Calendar, Plus, Settings } from 'lucide-react';
+import { Home, Plus, Settings } from 'lucide-react';
 import {
     NavigationWrapper,
     NavigationContainer,
@@ -13,7 +13,6 @@ import type { NavigationProps } from './Navigation.types';
 
 const navItems = [
     { to: '/', icon: Home, labelKey: 'Dashboard' },
-    { to: '/care', icon: Calendar, labelKey: 'Calendar' },
     { to: '/add', icon: Plus, labelKey: 'Add' },
     { to: '/settings', icon: Settings, labelKey: 'Settings' },
 ] as const;

--- a/src/pages/PlantDetail/PlantDetail.tsx
+++ b/src/pages/PlantDetail/PlantDetail.tsx
@@ -14,10 +14,6 @@ import {
     ScientificName,
     TagsContainer,
     Tag,
-    HealthSection,
-    HealthLabel,
-    HealthBar,
-    HealthIndicator,
     InfoCardsContainer,
     InfoCard,
     InfoIconWrapper,
@@ -138,8 +134,7 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
         ? getRelativeWateringDay(new Date(plant.lastWatered.getTime() + 5 * 24 * 60 * 60 * 1000), t)
         : t('NotSet');
 
-    // Health percentage (mock value for demo)
-    const healthPercentage = 92; return (
+    return (
         <PageLayout
             title={plant.name}
             subtitle={plant.scientificName || t('PlantDetails')}
@@ -163,15 +158,6 @@ const PlantDetail: React.FC<PlantDetailProps> = ({ className }) => {
                         </PlantDetails>
                     </PlantInfo>
 
-                    <HealthSection>
-                        <HealthLabel>
-                            <span>{t('PlantHealth')}</span>
-                            <span>{healthPercentage}%</span>
-                        </HealthLabel>
-                        <HealthBar>
-                            <HealthIndicator percent={healthPercentage} />
-                        </HealthBar>
-                    </HealthSection>
                 </ProfileCard>
 
                 <InfoCardsContainer>


### PR DESCRIPTION
## Summary
- remove calendar page from router and navigation
- hide health bar from plant detail page

## Testing
- `npm run lint` *(fails: 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68441a1a6f0c83289c9c6cd214c95d68