### PR TITLE
Add scanning spinner overlay

### DIFF
--- a/src/pages/Add/Add.styles.tsx
+++ b/src/pages/Add/Add.styles.tsx
@@ -192,3 +192,17 @@ export const SaveButton = styled(Button).attrs({ variant: 'primary' })`
   width: 100%;
   margin-top: ${({ theme }) => theme.spacing.xl};
 `;
+
+export const ScanOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${({ theme }) => theme.colors.overlay};
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+`;


### PR DESCRIPTION
## Summary
- show a loader overlay while scanning plant information
- handle scan promise to track async OpenAI request

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68442645a9e8832881ad6797cabc28b8